### PR TITLE
Turn repo in to a python package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ dist
 
 # Eleventy local development
 _site
+
+# Python package
+.eggs
+*.egg-info

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include system *

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Democracy Club design system
+
+Documentation: https://democracyclub.github.io/design-system/
+
+## Use in 3rd party applications
+
+### Python
+
+The design system can be installed using python package managers like `pip` or `pipenv`:
+
+`pip install git+https://github.com/DemocracyClub/design-system.git@VERSION`
+
+It's strongly recommended to pin to a version tag when using in real world applications.
+
+Once installed, all the assets in the `system` directory will be in your `site-packages` folder. To use access them you can import the design system in to your application and use `DC_SYSTEM_PATH`:
+
+```
+import dc_design_system
+dc_design_system.DC_SYSTEM_PATH
+```
+
+You can use this path when compiling the sass by passing it to the include paths.
+
+At this point you can follow the main usage instructions (TODO) to implement.
+
+
+

--- a/python-package/__init__.py
+++ b/python-package/__init__.py
@@ -1,0 +1,5 @@
+import os
+
+package_path = os.path.dirname(os.path.abspath(__file__))
+
+DC_SYSTEM_PATH = package_path

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 import os
+import json
 
 from setuptools import setup
 
+def get_version():
+    package_json = json.load(open("package.json"))
+    return package_json["version"]
+
 setup(
     name="dc_design_system",
-    version="0.0.1",
+    version=get_version(),
     description="SCSS and images for the DC design system",
     author="Sym Roe",
     author_email="sym.roe@democracyclub.org.uk",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import os
+
+from setuptools import setup
+
+setup(
+    name="dc_design_system",
+    version="0.0.1",
+    description="SCSS and images for the DC design system",
+    author="Sym Roe",
+    author_email="sym.roe@democracyclub.org.uk",
+    packages=[
+        "dc_design_system",
+        "dc_design_system/system",
+    ],
+    package_dir={
+        "dc_design_system": "python-package",
+        "dc_design_system/system": "system",
+    },
+    package_data={
+        "dc_design_system/system": [
+            "*",
+            "**/*",
+        ]
+    },
+    setup_requires=["wheel"],
+)


### PR DESCRIPTION
This PR makes the design system installable via `pip` or other standard python packaging tools.

For testing before merge, use `pip install git+https://github.com/DemocracyClub/design-system.git@python-package`.

This will install a python package that can be imported:

`import dc_design_system`

The only thing this package does is to expose the directory it lives in:

```
>>> import dc_design_system
>>> dc_design_system.DC_SYSTEM_PATH
'/home/symroe/.envs/design_system/lib/python3.8/site-packages/dc_design_system'
```

This tells us that the `system` folder in this repo is at `/home/symroe/.envs/design_system/lib/python3.8/site-packages/dc_design_system/system`.

This path can be used by `libsass` as an `include-path`, meaning that, once installed you can write _project level_ sass assuming the `system` is assessable.

e.g, you can do this:

`@import 'partials/_button.scss';`

## TODO

* [x] I've called the folder `python` to indicate that this is about python, assuming we might want to include other package managers in the future. Does this make sense? Should it be `python-package` or something?
* [x] Do we want to think about the names of things, given we might be using the system in other contexts? For example, `system/partials/_button.scss` is less clear than `dc_design_system/partials/_button.scss` (or whatever). I can rename this in the python package of course.
* [x] We should get a working version of this in an actual project before merging @VirginiaDooley let's pair on this.