### PR TITLE
Use display:inline-block on breadcrumbs to prevent clash with cards

### DIFF
--- a/system/partials/_breadcrumbs.scss
+++ b/system/partials/_breadcrumbs.scss
@@ -5,6 +5,7 @@
     margin: 0;
     padding: 0;
     list-style: none;
+    display: inline-block;
   }
 
   nav.ds-breadcrumbs li {


### PR DESCRIPTION
Fixes #12

I don't know if `inline-block` is best here - it also works with `overflow: auto`.

@Heydon would you be able to give some advice? Or a :+1: if you think this is ok to merge?