### PR TITLE
candidate breakpoint for narrow viewports

### DIFF
--- a/docs/basics/colors/index.html
+++ b/docs/basics/colors/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Colors (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>

--- a/docs/basics/dark/index.html
+++ b/docs/basics/dark/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Dark theme (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>

--- a/docs/basics/forms/index.html
+++ b/docs/basics/forms/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Forms (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
@@ -268,7 +268,7 @@
 <aside class="site-note site-stack" style="--stack-space: 1rem" aria-labelledby="stack-spacing">
   <h3 id="stack-spacing">🗒️ Stack spacing</h3>
   <div class="site-stack">
-<p>Note the use of the <a href="https://DemocracyClub.github.io/design-system/components/stack">Stack</a> component (<code>class=&quot;ds-stack-smallest&quot;</code>) to space out each <code>class=&quot;ds-field-radio&quot;</code> element.</p>
+<p>Note the use of the <a href="/components/stack">Stack</a> component (<code>class=&quot;ds-stack-smallest&quot;</code>) to space out each <code>class=&quot;ds-field-radio&quot;</code> element.</p>
 </div>
 </aside>
       </main>

--- a/docs/basics/modular-scale/index.html
+++ b/docs/basics/modular-scale/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Modular scale (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>

--- a/docs/basics/type/index.html
+++ b/docs/basics/type/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Type (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
@@ -210,7 +210,7 @@
 <aside class="site-note-warning site-stack" style="--stack-space: 1rem" aria-labelledby="white-space">
   <h3 id="white-space">⚠️ White space</h3>
   <div class="site-stack">
-<p>For consistency, the design system does not apply margin directly to elements. Instead, it is applied contextually using the <a href="https://DemocracyClub.github.io/design-system/components/stack">Stack</a> component.</p>
+<p>For consistency, the design system does not apply margin directly to elements. Instead, it is applied contextually using the <a href="/components/stack">Stack</a> component.</p>
 </div>
 </aside>
       </main>

--- a/docs/components/breadcrumbs/index.html
+++ b/docs/components/breadcrumbs/index.html
@@ -2,128 +2,128 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Breadcrumbs (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
       <main id="main" tabindex="-1">
         <h1>Breadcrumbs</h1>
-        <p>Use the Breadcrumbs component when the site structure is several levels deep and a secondary wayfinding mechanism (in addition to the <a href="https://DemocracyClub.github.io/design-system/components/header">Header’s</a> navigation links) may be useful.</p>
-<p>Unlike <a href="https://DemocracyClub.github.io/design-system/components/subnavigation">Sub-navigation</a>, breadcrumbs represent levels of depth reading from left to right. Use <a href="https://DemocracyClub.github.io/design-system/components/subnavigation">Sub-navigation</a> where each link represents a topic belonging to the <em>same</em> level.</p>
+        <p>Use the Breadcrumbs component when the site structure is several levels deep and a secondary wayfinding mechanism (in addition to the <a href="/components/header">Header’s</a> navigation links) may be useful.</p>
+<p>Unlike <a href="/components/subnavigation">Sub-navigation</a>, breadcrumbs represent levels of depth reading from left to right. Use <a href="/components/subnavigation">Sub-navigation</a> where each link represents a topic belonging to the <em>same</em> level.</p>
 <div class="ds-scope">
   <nav class="ds-breadcrumbs" aria-label="Where you are">
     <ol>

--- a/docs/components/button/index.html
+++ b/docs/components/button/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Button (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>

--- a/docs/components/call-to-action/index.html
+++ b/docs/components/call-to-action/index.html
@@ -2,128 +2,128 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Call-to-action (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
       <main id="main" tabindex="-1">
         <h1>Call-to-action</h1>
-        <p>Use Calls-to-action (CTAs) for linking to important places. Calls-to-action are highlighted hyperlinks. Accordingly, styles are only honored for <code>&lt;a&gt;</code> elements with <code>href</code> attributes. For button styles see <a href="https://DemocracyClub.github.io/design-system/components/button">Button</a>.</p>
-<p>Omitting the <code>href</code> is equivalent to using <code>disabled</code> on a <code>&lt;button&gt;</code> element, hence the opacity and cursor styles matching those of disabled <a href="https://DemocracyClub.github.io/design-system/components/button">Buttons</a>.</p>
+        <p>Use Calls-to-action (CTAs) for linking to important places. Calls-to-action are highlighted hyperlinks. Accordingly, styles are only honored for <code>&lt;a&gt;</code> elements with <code>href</code> attributes. For button styles see <a href="/components/button">Button</a>.</p>
+<p>Omitting the <code>href</code> is equivalent to using <code>disabled</code> on a <code>&lt;button&gt;</code> element, hence the opacity and cursor styles matching those of disabled <a href="/components/button">Buttons</a>.</p>
 <table class="site-table" style="table-layout: fixed">
   <tr>
     <th>markup</th>

--- a/docs/components/candidate/index.html
+++ b/docs/components/candidate/index.html
@@ -2,128 +2,128 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Candidate (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
       <main id="main" tabindex="-1">
         <h1>Candidate</h1>
         <p>Use the Candidate component for summarizing key information about a political candidate.</p>
-<p>The Candidate component is a special kind of card. For all other card use cases, see the generic <a href="https://DemocracyClub.github.io/design-system/components/card">Card</a>. The following demo uses a <a href="https://DemocracyClub.github.io/design-system/components/grid">Grid</a> as a list (<code>&lt;ul&gt;</code>) to display a list of cards.</p>
+<p>The Candidate component is a special kind of card. For all other card use cases, see the generic <a href="/components/card">Card</a>. The following demo uses a <a href="/components/grid">Grid</a> as a list (<code>&lt;ul&gt;</code>) to display a list of cards.</p>
 <div class="ds-scope">
   <div class="site-resizer">
     <ul class="ds-grid">
@@ -135,7 +135,7 @@
           <div class="ds-h6">Labour</div>
         </div>
         <div class="ds-candidate-image">
-          <img src="https://DemocracyClub.github.io/design-system/images/candidate_example.jpg" alt="">
+          <img src="/images/candidate_example.jpg" alt="">
         </div>
       </li>
       <li class="ds-candidate">
@@ -146,7 +146,7 @@
           <div class="ds-h6">Independent</div>
         </div>
         <div class="ds-candidate-image">
-          <img src="https://DemocracyClub.github.io/design-system/images/candidate_example_2.jpg" alt="">
+          <img src="/images/candidate_example_2.jpg" alt="">
         </div>
       </li>
       <li class="ds-candidate">
@@ -157,7 +157,7 @@
           <div class="ds-h6">Conservative & Unionist Party</div>
         </div>
         <div class="ds-candidate-image">
-          <img src="https://DemocracyClub.github.io/design-system/images/candidate_example_3.jpg" alt="">
+          <img src="/images/candidate_example_3.jpg" alt="">
         </div>
       </li>
     </ul>
@@ -205,7 +205,7 @@
       <p>Animi maiores, earum quisquam porro mollitia maxime pariatur iure esse nesciunt obcaecati deleniti explicabo a, veritatis voluptatum, suscipit ipsum illo provident temporibus.</p>
     </div>
     <div class="ds-candidate-image">
-      <img src="https://DemocracyClub.github.io/design-system/images/candidate_example.jpg" alt="">
+      <img src="/images/candidate_example.jpg" alt="">
     </div>
   </div>
 </div>
@@ -222,7 +222,7 @@
           <div class="ds-h6">Labour</div>
         </div>
         <div class="ds-candidate-image">
-          <img src="https://DemocracyClub.github.io/design-system/images/candidate_example.jpg" alt="">
+          <img src="/images/candidate_example.jpg" alt="">
         </div>
       </li>
       <li class="ds-candidate">
@@ -233,7 +233,7 @@
           <div class="ds-h6">Independent</div>
         </div>
         <div class="ds-candidate-image">
-          <img src="https://DemocracyClub.github.io/design-system/images/candidate_example_2.jpg" alt="">
+          <img src="/images/candidate_example_2.jpg" alt="">
         </div>
       </li>
       <li class="ds-candidate">
@@ -244,7 +244,7 @@
           <div class="ds-h6">Conservative & Unionist Party</div>
         </div>
         <div class="ds-candidate-image">
-          <img src="https://DemocracyClub.github.io/design-system/images/candidate_example_3.jpg" alt="">
+          <img src="/images/candidate_example_3.jpg" alt="">
         </div>
       </li>
     </ul>

--- a/docs/components/card/index.html
+++ b/docs/components/card/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Card (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
@@ -131,7 +131,7 @@
     </div>
   </div>
 </div>
-<p>The <code>.ds-card-body</code> class extends the <code>.ds-card-smaller</code> class from <a href="https://DemocracyClub.github.io/design-system/components/stack">Stack</a> to space the elements inside it.</p>
+<p>The <code>.ds-card-body</code> class extends the <code>.ds-card-smaller</code> class from <a href="/components/stack">Stack</a> to space the elements inside it.</p>
 <pre><code class="language-html">&lt;div class=&quot;ds-card&quot;&gt;
   &lt;div class=&quot;ds-card-body&quot;&gt;
     &lt;h3&gt;&lt;a class=&quot;ds-card-link&quot; href=&quot;#&quot;&gt;Card&lt;/a&gt;&lt;/h3&gt;
@@ -145,7 +145,7 @@
   <h3 id="not-everything-is-a-card!">⚠️ Not everything is a card!</h3>
   <div class="site-stack">
 <p>At the time of writing, Cards are used liberally across the Democracy Club sites. Don’t “turn everything up to eleven”; as a rule of thumb, only use a standalone Card once or twice in a page.</p>
-<p>Only use multiple successive cards within a <a href="https://DemocracyClub.github.io/design-system/components/grid">Grid</a>. See an example on the <a href="https://DemocracyClub.github.io/design-system/components/grid">Grid</a> page.</p>
+<p>Only use multiple successive cards within a <a href="/components/grid">Grid</a>. See an example on the <a href="/components/grid">Grid</a> page.</p>
 </div>
 </aside>
 <h2>Image cards</h2>
@@ -153,7 +153,7 @@
 <div class="ds-scope">
   <div class="ds-card">
     <div class="ds-card-image">
-      <img src="https://DemocracyClub.github.io/design-system/images/card_example.jpg" alt="">
+      <img src="/images/card_example.jpg" alt="">
     </div>
     <div class="ds-card-body">
       <h3><a class="ds-card-link" href="#">Card with image</a></h3>

--- a/docs/components/checkbox/index.html
+++ b/docs/components/checkbox/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Checkbox (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>

--- a/docs/components/cluster/index.html
+++ b/docs/components/cluster/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Cluster (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>

--- a/docs/components/codeblock/index.html
+++ b/docs/components/codeblock/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Code block (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>

--- a/docs/components/description-lists/index.html
+++ b/docs/components/description-lists/index.html
@@ -2,127 +2,127 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Description lists (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
       <main id="main" tabindex="-1">
         <h1>Description lists</h1>
-        <p>Use a description (or “definition”) list to highlight key information, such a contact details. Use a <a href="https://DemocracyClub.github.io/design-system/components/table">Table</a> if the information is more complex than simple key/value pairs.</p>
+        <p>Use a description (or “definition”) list to highlight key information, such a contact details. Use a <a href="/components/table">Table</a> if the information is more complex than simple key/value pairs.</p>
 <div class="ds-scope">
   <dl class="ds-descriptions">
     <div>

--- a/docs/components/details/index.html
+++ b/docs/components/details/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Details (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>

--- a/docs/components/filter/index.html
+++ b/docs/components/filter/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Filter (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
@@ -205,7 +205,7 @@
 <ul>
 <li>The element is an <code>&lt;aside&gt;</code> so it is discoverable using screen readers and is labeled using the first list item of the top-level filters list (<code>aria-labelledby</code> and the <code>id</code> match).</li>
 <li>This element is hidden to assistive technologies with <code>aria-hidden</code> so is it is not enumerated as part of the list (this does not negate the <code>aria-labelledby</code> labeling mechanism).</li>
-<li>Advanced filters can be accessed using a <a href="https://DemocracyClub.github.io/design-system/components/details">Details</a> component.</li>
+<li>Advanced filters can be accessed using a <a href="/components/details">Details</a> component.</li>
 <li>Advanced filters are grouped inside the <code>class=&quot;ds-advanced-filters&quot;</code> element.</li>
 <li>Each advanced filter <code>&lt;ul&gt;</code> is labeled by the first <code>&lt;li&gt;</code> element using <code>aria-labelledby</code></li>
 <li>The <code>aria-current=&quot;true&quot;</code> attribution is used on the currently selected filter (as defined by the query parameter).</li>

--- a/docs/components/footer/index.html
+++ b/docs/components/footer/index.html
@@ -2,128 +2,128 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Footer (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
       <main id="main" tabindex="-1">
         <h1>Footer</h1>
         <p>Use the Footer component to add quick links, company, and contact information to the foot of a page.</p>
-<p>A basic footer looks something like the following (as seen in <a href="https://DemocracyClub.github.io/design-system/layout-demo/">the page layout demo</a>. All the <code>ds-footer</code> class does is add some padding, the blue top border, and extend the <a href="https://DemocracyClub.github.io/design-system/basics/dark">Dark theme</a>.</p>
+<p>A basic footer looks something like the following (as seen in <a href="/layout-demo/">the page layout demo</a>. All the <code>ds-footer</code> class does is add some padding, the blue top border, and extend the <a href="/basics/dark">Dark theme</a>.</p>
 <p>Aside from that, only <code>ds-copyright</code> is unique to this component. The content of the footer can be constructed from other components according to your needs. In the following example, a list of “quick links” is provided alongside the copyright.</p>
 <div class="ds-scope">
   <footer class="ds-footer">
@@ -155,7 +155,7 @@
       </div>
       <div class="ds-copyright">
         <a href="https://democracyclub.org.uk/">
-          <img src="https://DemocracyClub.github.io/design-system/images/logo_white_text.svg" alt="Democracy Club Home" />
+          <img src="/images/logo_white_text.svg" alt="Democracy Club Home" />
         </a>
         <p>Copyright © 2021 Democracy Club</p>
         <p>Community Interest Company</p>
@@ -175,7 +175,7 @@
     &lt;/div&gt;
     &lt;div class=&quot;ds-copyright&quot;&gt;
       &lt;a href=&quot;https://democracyclub.org.uk/&quot;&gt;
-        &lt;img src=&quot;https://DemocracyClub.github.io/design-system/images/logo_white_text.svg&quot; alt=&quot;Democracy Club Home&quot; /&gt;
+        &lt;img src=&quot;/images/logo_white_text.svg&quot; alt=&quot;Democracy Club Home&quot; /&gt;
       &lt;/a&gt;
       &lt;p&gt;Copyright © 2021 Democracy Club&lt;/p&gt;
       &lt;p&gt;Community Interest Company&lt;/p&gt;

--- a/docs/components/grid/index.html
+++ b/docs/components/grid/index.html
@@ -2,128 +2,128 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Grid (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
       <main id="main" tabindex="-1">
         <h1>Grid</h1>
-        <p>Use the Grid component to display related/equivalent items such as <a href="https://DemocracyClub.github.io/design-system/components/card">Cards</a> in a responsive grid-like formation.</p>
-<p>Grid progressively enhances a single column layout (with basic <a href="https://DemocracyClub.github.io/design-system/components/stack">Stack</a>-like spacing) into a configurable CSS Grid layout.</p>
+        <p>Use the Grid component to display related/equivalent items such as <a href="/components/card">Cards</a> in a responsive grid-like formation.</p>
+<p>Grid progressively enhances a single column layout (with basic <a href="/components/stack">Stack</a>-like spacing) into a configurable CSS Grid layout.</p>
 <div class="ds-scope site-resizer">
   <ul class="ds-grid">
     <li class="ds-card">

--- a/docs/components/header/index.html
+++ b/docs/components/header/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Header (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
@@ -126,7 +126,7 @@
 <div class="ds-scope site-resizer">
   <header class="ds-header">
     <a class="ds-logo" href="/">
-      <img src="https://DemocracyClub.github.io/design-system/images/logo_icon.svg" alt="" />
+      <img src="/images/logo_icon.svg" alt="" />
       <span>democracy<br>club</span>
     </a>
     <nav>
@@ -191,7 +191,7 @@
 <aside class="site-note site-stack" style="--stack-space: 1rem" aria-labelledby="current-page-indication">
   <h3 id="current-page-indication">🗒️ Current page indication</h3>
   <div class="site-stack">
-<p>The <code>aria-current=&quot;true&quot;</code> attribution indicates which navigation link corresponds to the current location (the <code>true</code> value is used in place of <code>page</code> because of the relationship to <a href="https://DemocracyClub.github.io/design-system/components/subnavigation">Sub-navigation</a>). This is placed on “About” (as in the previous code sample) where the user is currently on the about page. This attribute helps screen reader users with wayfinding and is the non-visual equivalent of the pink underline.</p>
+<p>The <code>aria-current=&quot;true&quot;</code> attribution indicates which navigation link corresponds to the current location (the <code>true</code> value is used in place of <code>page</code> because of the relationship to <a href="/components/subnavigation">Sub-navigation</a>). This is placed on “About” (as in the previous code sample) where the user is currently on the about page. This attribute helps screen reader users with wayfinding and is the non-visual equivalent of the pink underline.</p>
 </div>
 </aside>
       </main>

--- a/docs/components/language/index.html
+++ b/docs/components/language/index.html
@@ -2,127 +2,127 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Language (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
       <main id="main" tabindex="-1">
         <h1>Language</h1>
-        <p>Include the language component as the first element after the skip link (see the <a href="https://DemocracyClub.github.io/design-system/layout-demo">layout demo</a> source).</p>
+        <p>Include the language component as the first element after the skip link (see the <a href="/layout-demo">layout demo</a> source).</p>
 <div class="ds-scope">
   <aside class="ds-language" aria-labelledby="language-label">
     <ul>

--- a/docs/components/logo/index.html
+++ b/docs/components/logo/index.html
@@ -2,144 +2,144 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Logo (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
       <main id="main" tabindex="-1">
         <h1>Logo</h1>
-        <p>The logo component is a link back to the local site’s homepage, most commonly included in the <a href="https://DemocracyClub.github.io/design-system/components/header">Header</a>. This text-based logo replaces purely image-based versions for ease of translation.</p>
+        <p>The logo component is a link back to the local site’s homepage, most commonly included in the <a href="/components/header">Header</a>. This text-based logo replaces purely image-based versions for ease of translation.</p>
 <div class="ds-scope">
   <div class="ds-stack-smaller">
     <div>
       <a class="ds-logo" href="/">
-        <img src="https://DemocracyClub.github.io/design-system/images/logo_icon.svg" alt="" />
+        <img src="/images/logo_icon.svg" alt="" />
         <span>democracy<br>club</span>
       </a>
     </div>
     <div>
       <a class="ds-logo" href="/">
-        <img src="https://DemocracyClub.github.io/design-system/images/logo_icon.svg" alt="" />
+        <img src="/images/logo_icon.svg" alt="" />
         <span>Who Can I Vote For?</span>
       </a>
     </div>
     <div>
       <a class="ds-logo" href="/">
-        <img src="https://DemocracyClub.github.io/design-system/images/logo_icon.svg" alt="" />
+        <img src="/images/logo_icon.svg" alt="" />
         <span>Where Do I Vote?</span>
       </a>
     </div>
@@ -148,14 +148,14 @@
 <h2>Markup</h2>
 <p>Since the text itself acts as the accessible label for the <code>ds-logo</code> link, the check mark graphic can be considered decorative. Therefore, it is supplied an empty <code>alt</code> string to suppress its readout in screen readers.</p>
 <pre><code class="language-html">&lt;a class=&quot;ds-logo&quot; href=&quot;/&quot;&gt;
-  &lt;img src=&quot;https://DemocracyClub.github.io/design-system/images/logo_icon.svg&quot; alt=&quot;&quot; /&gt;
+  &lt;img src=&quot;/images/logo_icon.svg&quot; alt=&quot;&quot; /&gt;
   &lt;span&gt;democracy club&lt;/span&gt;
 &lt;/a&gt;
 </code></pre>
 <h3>Welsh variant</h3>
 <div class="ds-scope">
   <a class="ds-logo" href="/">
-    <img src="https://DemocracyClub.github.io/design-system/images/logo_icon.svg" alt="" />
+    <img src="/images/logo_icon.svg" alt="" />
     <span>
       Where Do I Vote?
       <em lang="cy">Ble Ydw i’n Pleidleisio?</em>
@@ -164,7 +164,7 @@
 </div>
 <p>Welsh versions of the logo should be in English <em>and</em> Welsh, using an <code>&lt;em&gt;</code> element to encapsulate the Welsh translation. The <code>&lt;em&gt;</code> needs to take <code>lang=&quot;cy&quot;</code>.</p>
 <pre><code class="language-html">&lt;a class=&quot;ds-logo&quot; href=&quot;/&quot;&gt;
-  &lt;img src=&quot;https://DemocracyClub.github.io/design-system/images/logo_icon.svg&quot; alt=&quot;&quot; /&gt;
+  &lt;img src=&quot;/images/logo_icon.svg&quot; alt=&quot;&quot; /&gt;
   &lt;span&gt;
     Where Do I Vote?
     &lt;em lang=&quot;cy&quot;&gt;Ble Ydw i’n Pleidleisio?&lt;/em&gt;
@@ -175,7 +175,7 @@
 <div class="ds-scope">
   <div class="ds-dark ds-padded">
     <a class="ds-logo" href="/">
-      <img src="https://DemocracyClub.github.io/design-system/images/logo_icon.svg" alt="" />
+      <img src="/images/logo_icon.svg" alt="" />
       <span>democracy<br>club</span>
     </a>    
   </div>

--- a/docs/components/radio-button/index.html
+++ b/docs/components/radio-button/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Radio buttons (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
@@ -145,7 +145,7 @@
   </form>
 </div>
 <p>Each radio button is wrapped in a <code>&lt;label&gt;</code> with <code>class=&quot;ds-field-radio&quot;</code> and the label text must be wrapped in a <code>&lt;span&gt;</code> for custom styling purposes.</p>
-<p>We can use a <a href="https://DemocracyClub.github.io/design-system/components/stack">Stack</a> component to space out each <code>class=&quot;ds-field-radio&quot;</code> element (<code>class=&quot;ds-stack-smallest&quot;</code>).</p>
+<p>We can use a <a href="/components/stack">Stack</a> component to space out each <code>class=&quot;ds-field-radio&quot;</code> element (<code>class=&quot;ds-stack-smallest&quot;</code>).</p>
 <pre><code class="language-html">&lt;fieldset&gt;
   &lt;legend&gt;Favorite type of democracy&lt;/legend&gt;
   &lt;div class=&quot;ds-stack-smallest&quot;&gt;
@@ -184,7 +184,7 @@
     </fieldset>
   </form>
 </div>
-<p>For inline radio buttons, we can use a <a href="https://DemocracyClub.github.io/design-system/components/cluster">Cluster</a> component, like so:</p>
+<p>For inline radio buttons, we can use a <a href="/components/cluster">Cluster</a> component, like so:</p>
 <pre><code class="language-html">&lt;div class=&quot;ds-cluster&quot;&gt;
   &lt;fieldset&gt;
     &lt;legend&gt;Favorite type of democracy&lt;/legend&gt;

--- a/docs/components/select/index.html
+++ b/docs/components/select/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Select (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>

--- a/docs/components/sidebar/index.html
+++ b/docs/components/sidebar/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Sidebar (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
@@ -167,7 +167,7 @@
   <div class="ds-with-sidebar">
     <div>
       <div class="ds-sidebar" style="flex-basis: 20rem">
-        <img src="https://DemocracyClub.github.io/design-system/images/card_example.jpg" alt="">
+        <img src="/images/card_example.jpg" alt="">
       </div>
       <div class="ds-not-sidebar">
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Libero reprehenderit a ipsa veniam molestias numquam blanditiis? Ab soluta odit consectetur commodi totam, quae debitis incidunt? Numquam consequuntur distinctio laboriosam culpa.</p>

--- a/docs/components/stack/index.html
+++ b/docs/components/stack/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Stack (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>

--- a/docs/components/status/index.html
+++ b/docs/components/status/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Status (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
@@ -142,7 +142,7 @@
   &lt;/ul&gt;
 &lt;/aside&gt;
 </code></pre>
-<p>The status component should typically be added to the page just below the <code>&lt;h1&gt;</code> (main) heading. See the <a href="https://DemocracyClub.github.io/design-system/layout-demo">layout demo</a>.</p>
+<p>The status component should typically be added to the page just below the <code>&lt;h1&gt;</code> (main) heading. See the <a href="/layout-demo">layout demo</a>.</p>
 
       </main>
     </div>

--- a/docs/components/subnavigation/index.html
+++ b/docs/components/subnavigation/index.html
@@ -2,127 +2,127 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Sub-navigation (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
       <main id="main" tabindex="-1">
         <h1>Sub-navigation</h1>
-        <p>Use the Sub-navigation component when there are pages available related to the chosen main navigation link (as indicated by <code>aria-current=&quot;true&quot;</code> in the <a href="https://DemocracyClub.github.io/design-system/components/header">Header</a> component above it). For example, if the chosen route on <a href="https://democracyclub.org.uk">democracyclub.org.uk</a> is “About”, use Sub-navigation to provide links to “About” (the index page), “The Team”, “Jobs”, and “Funding”. This group of pages represents a subsection of the site called “About”.</p>
+        <p>Use the Sub-navigation component when there are pages available related to the chosen main navigation link (as indicated by <code>aria-current=&quot;true&quot;</code> in the <a href="/components/header">Header</a> component above it). For example, if the chosen route on <a href="https://democracyclub.org.uk">democracyclub.org.uk</a> is “About”, use Sub-navigation to provide links to “About” (the index page), “The Team”, “Jobs”, and “Funding”. This group of pages represents a subsection of the site called “About”.</p>
 <div class="ds-scope">
   <nav class="ds-subnav" aria-label="About">
     <ul>
@@ -144,7 +144,7 @@
 <aside class="site-note site-stack" style="--stack-space: 1rem" aria-labelledby="breadcrumbs">
   <h3 id="breadcrumbs">🗒️ Breadcrumbs</h3>
   <div class="site-stack">
-<p>If you wish to indicate <em>depth</em> of location (how many links deep into a subsection of the site), use the <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs">Breadcrumbs</a> component instead.</p>
+<p>If you wish to indicate <em>depth</em> of location (how many links deep into a subsection of the site), use the <a href="/components/breadcrumbs">Breadcrumbs</a> component instead.</p>
 </div>
 </aside>
 <p>The <code>class=&quot;ds-subnav&quot;</code> element is a <code>&lt;nav&gt;</code>, exposing it as a landmark region to screen readers. Note the use of <code>aria-label=&quot;About&quot;</code>. This differentiates this navigation landmark from the main one above it in screen reader landmark listings. Where the section is “Our work”, use <code>aria-label=&quot;Our work&quot;</code>.</p>
@@ -169,7 +169,7 @@
 <aside class="site-note-warning site-stack" style="--stack-space: 1rem" aria-labelledby="source-order">
   <h3 id="source-order">⚠️ Source order</h3>
   <div class="site-stack">
-<p>As demonstrated in the <a href="https://DemocracyClub.github.io/design-system/layout-demo">page layout demo</a>, the Sub-navigation component should appear first inside the <code>&lt;main&gt;</code> element, <em>before</em> the page’s <code>&lt;h1&gt;</code>. This is better for screen reader accessibility than the reverse configuration used in the live <a href="https://democracyclub.org.uk">democracyclub.org.uk</a> site at the time of writing.</p>
+<p>As demonstrated in the <a href="/layout-demo">page layout demo</a>, the Sub-navigation component should appear first inside the <code>&lt;main&gt;</code> element, <em>before</em> the page’s <code>&lt;h1&gt;</code>. This is better for screen reader accessibility than the reverse configuration used in the live <a href="https://democracyclub.org.uk">democracyclub.org.uk</a> site at the time of writing.</p>
 <pre><code class="language-html">&lt;main id=&quot;main&quot; tabindex=&quot;-1&quot;&gt;
   &lt;nav class=&quot;ds-subnav&quot; aria-label=&quot;About&quot;&gt;
     &lt;!-- Sub-navigation links --&gt;

--- a/docs/components/table/index.html
+++ b/docs/components/table/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Table (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
@@ -278,7 +278,7 @@
   </div>
 </div>
 <h2>Tables in cards</h2>
-<p>You can use a <a href="https://DemocracyClub.github.io/design-system/components/card">Card</a> to “lift” a table and give it more affordance in the page.</p>
+<p>You can use a <a href="/components/card">Card</a> to “lift” a table and give it more affordance in the page.</p>
 <div class="ds-scope">
   <div class="ds-card ds-padded">
     <div class="ds-table">
@@ -319,7 +319,7 @@
 <aside class="site-note site-stack" style="--stack-space: 1rem" aria-labelledby="padding-options">
   <h3 id="padding-options">🗒️ Padding options</h3>
   <div class="site-stack">
-<p>In this case, the <code>ds-padded</code> <a href="https://DemocracyClub.github.io/design-system/components/utilities">utility class</a> to pad the card. Alternatively, I could wrap the table in a <code>class=&quot;ds-card-body&quot;</code> element.</p>
+<p>In this case, the <code>ds-padded</code> <a href="/components/utilities">utility class</a> to pad the card. Alternatively, I could wrap the table in a <code>class=&quot;ds-card-body&quot;</code> element.</p>
 <pre><code class="language-html">&lt;div class=&quot;ds-card ds-padded&quot;&gt;
   &lt;div class=&quot;ds-card-body&quot;&gt;
     &lt;div class=&quot;ds-table&quot;&gt;

--- a/docs/components/utilities/index.html
+++ b/docs/components/utilities/index.html
@@ -2,127 +2,127 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Utility classes (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
       <main id="main" tabindex="-1">
         <h1>Utility classes</h1>
-        <p>These utility classes are a toolkit for making simple design/layout adjustments to individual elements. For generic layout helpers (concerning multiple elements), see <a href="https://DemocracyClub.github.io/design-system/components/cluster">Cluster</a>, <a href="https://DemocracyClub.github.io/design-system/components/stack">Stack</a>, <a href="https://DemocracyClub.github.io/design-system/components/grid">Grid</a>, and <a href="https://DemocracyClub.github.io/design-system/components/sidebar">Sidebar</a>.</p>
+        <p>These utility classes are a toolkit for making simple design/layout adjustments to individual elements. For generic layout helpers (concerning multiple elements), see <a href="/components/cluster">Cluster</a>, <a href="/components/stack">Stack</a>, <a href="/components/grid">Grid</a>, and <a href="/components/sidebar">Sidebar</a>.</p>
 <table class="site-table">
   <tr>
     <th>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Democracy Club’s Design System (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
@@ -127,7 +127,7 @@
 <h2>Contributing</h2>
 <p>Before contributing a new component to the design system, you must do two things:</p>
 <ol>
-<li><strong>Find out if it already exists</strong>. It’s likely the component you want either exists (just not exactly as you imagined), has an equivalent that does the same job (you probably just want that), or can be created using a combination of existing components and <a href="https://DemocracyClub.github.io/design-system/components/utilities/">utility classes</a>. If you encounter problems, <a href="https://github.com/DemocracyClub/design-system/issues/new/choose">raise an issue</a>.</li>
+<li><strong>Find out if it already exists</strong>. It’s likely the component you want either exists (just not exactly as you imagined), has an equivalent that does the same job (you probably just want that), or can be created using a combination of existing components and <a href="/components/utilities/">utility classes</a>. If you encounter problems, <a href="https://github.com/DemocracyClub/design-system/issues/new/choose">raise an issue</a>.</li>
 <li><strong>Raise an issue</strong>. Before embarking on making the component (part component or other feature), raise an issue to make your intent public and confirm the necessity. Use the <strong>addition</strong> label.</li>
 </ol>
 <p>When creating your component, follow these steps.</p>

--- a/docs/layout-demo/index.html
+++ b/docs/layout-demo/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Page layout demo (Democracy Club Design System)</title>
   </head>
   <body class="ds-scope" style="margin: 0">
@@ -18,7 +18,7 @@
 </aside>
 <header class="ds-header">
   <a class="ds-logo" href="/">
-    <img src="https://DemocracyClub.github.io/design-system/images/logo_icon.svg" alt="" />
+    <img src="/images/logo_icon.svg" alt="" />
     <span>democracy<br>club</span>
   </a>
   <nav>
@@ -71,7 +71,7 @@
     </ul>
   </aside>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Dignissimos pariatur iusto officia necessitatibus distinctio nemo perspiciatis placeat illo facilis enim soluta et accusamus sunt ipsa fugit earum, voluptas assumenda aspernatur.</p>
-    <dl class="ds-descriptions">
+  <dl class="ds-descriptions">
     <div>
       <dt>Facebook</dt>
       <dd><a href="https://www.facebook.com/shaunbaileyuk">www.facebook.com/shaunbaileyuk</a></dd>
@@ -92,6 +92,41 @@
     </div>
   </dl>
   <p>Distinctio iure explicabo quaerat repudiandae, nulla officia corporis! Eaque sapiente excepturi quas, nostrum cumque nisi. Quis eligendi necessitatibus, fugit voluptatem a, voluptatibus praesentium fugiat, nostrum doloremque eum est ratione provident.</p>
+  <ul class="ds-grid">
+    <li class="ds-candidate">
+      <div class="ds-candidate-body ds-stack-smallest">
+        <h3 class="ds-candidate-name ds-h5">
+          <a href="path/to/candidate">Michael Rosen</a>
+        </h3>
+        <div class="ds-h6">Labour</div>
+      </div>
+      <div class="ds-candidate-image">
+        <img src="/images/candidate_example.jpg" alt="">
+      </div>
+    </li>
+    <li class="ds-candidate">
+      <div class="ds-candidate-body ds-stack-smallest">
+        <h3 class="ds-candidate-name ds-h5">
+          <a href="path/to/candidate">David Moreland</a>
+        </h3>
+        <div class="ds-h6">Independent</div>
+      </div>
+      <div class="ds-candidate-image">
+        <img src="/images/candidate_example_2.jpg" alt="">
+      </div>
+    </li>
+    <li class="ds-candidate">
+      <div class="ds-candidate-body ds-stack-smallest">
+        <h3 class="ds-candidate-name ds-h5">
+          <a href="path/to/candidate">Giles Orpen-Smellie</a>
+        </h3>
+        <div class="ds-h6">Conservative & Unionist Party</div>
+      </div>
+      <div class="ds-candidate-image">
+        <img src="/images/candidate_example_3.jpg" alt="">
+      </div>
+    </li>
+  </ul>
   <h2>A subheading</h2>
   <p>Dignissimos asperiores sequi soluta, nemo voluptatum molestias repudiandae sunt mollitia placeat magnam sapiente inventore optio iure corporis facere laboriosam dolorem nisi nobis amet minima modi, adipisci tempora voluptatibus? Id, perspiciatis.</p>
   <div class="ds-candidate">
@@ -103,7 +138,7 @@
       <p>Animi maiores, earum quisquam porro mollitia maxime pariatur iure esse nesciunt obcaecati deleniti explicabo a, veritatis voluptatum, suscipit ipsum illo provident temporibus.</p>
     </div>
     <div class="ds-candidate-image">
-      <img src="https://DemocracyClub.github.io/design-system/images/candidate_example_2.jpg" alt="">
+      <img src="/images/candidate_example_2.jpg" alt="">
     </div>
   </div>
 </main>
@@ -136,7 +171,7 @@
     </div>
     <div class="ds-copyright ds-text-centered">
       <a href="https://democracyclub.org.uk/">
-        <img src="https://DemocracyClub.github.io/design-system/images/logo_white_text.svg" alt="Democracy Club Home" />
+        <img src="/images/logo_white_text.svg" alt="Democracy Club Home" />
       </a>
       <p>Copyright © 2021 Democracy Club</p>
       <p>Community Interest Company</p>

--- a/docs/styles/system.css
+++ b/docs/styles/system.css
@@ -623,7 +623,7 @@
     left: 0;
     z-index: 2; }
   .ds-scope .ds-candidate-image {
-    background-color: rgba(64, 63, 65, 0.2);
+    background-color: #efefef;
     flex-grow: 1;
     min-width: 10rem;
     min-width: min(10rem, 100%);
@@ -639,6 +639,23 @@
     .ds-scope .ds-candidate-image img {
       object-fit: cover;
       width: 100%; } }
+  @media (max-width: 400px) {
+    .ds-scope li.ds-candidate {
+      flex-wrap: nowrap; }
+    .ds-scope li .ds-candidate-body, .ds-scope li .ds-candidate-image {
+      padding: 1rem; }
+    .ds-scope li .ds-candidate-image {
+      background-color: transparent;
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      min-height: 0; }
+    .ds-scope li .ds-candidate-image img {
+      position: static;
+      object-fit: inherit;
+      height: 12vh;
+      width: auto;
+      margin-left: auto; } }
   .ds-scope .ds-candidate:focus-within {
     outline: 0.25rem solid #FFC037; }
   .ds-scope .ds-candidate:focus-within a:focus {

--- a/docs/usage/composition/index.html
+++ b/docs/usage/composition/index.html
@@ -2,127 +2,127 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Composing content (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
       <main id="main" tabindex="-1">
         <h1>Composing content</h1>
-        <p>By combining <a href="https://DemocracyClub.github.io/design-system/components/stack">Stacks</a>, <a href="https://DemocracyClub.github.io/design-system/components/grid">Grids</a>, and the various components, you can quickly compose responsive layouts like the following “kitchen sink” example.</p>
+        <p>By combining <a href="/components/stack">Stacks</a>, <a href="/components/grid">Grids</a>, and the various components, you can quickly compose responsive layouts like the following “kitchen sink” example.</p>
 <div class="site-resizer">
   <div class="ds-scope">
     <div class="ds-stack">

--- a/docs/usage/getting-started/index.html
+++ b/docs/usage/getting-started/index.html
@@ -2,121 +2,121 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Getting started (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
@@ -146,7 +146,7 @@ docs.scss
 <p>The <code>index.template.scss</code> file is a template for how you would pull in the partials and get the system running in your project.</p>
 <h2>Sass compilation</h2>
 <p>The first thing you need to do is take <code>index.template.scss</code>, rename it if you desire, and make it the “in” file for Sass compilation. To reach the associated partials, you will need to configure <code>libsass</code> to use the folder exposed in the installation step above as an <code>include-path</code>.</p>
-<p>Note the <code>optional-styles</code> block in that file. For efficiency, you should comment out any components here you know you don’t need, keeping the design system’s footprint as small as possible. In the following example, I have commented out the <a href="https://DemocracyClub.github.io/design-system/components/sidebar">Sidebar</a>, <a href="https://DemocracyClub.github.io/design-system/components/table">Table</a>, and <a href="https://DemocracyClub.github.io/design-system/components/select">Select</a> components.</p>
+<p>Note the <code>optional-styles</code> block in that file. For efficiency, you should comment out any components here you know you don’t need, keeping the design system’s footprint as small as possible. In the following example, I have commented out the <a href="/components/sidebar">Sidebar</a>, <a href="/components/table">Table</a>, and <a href="/components/select">Select</a> components.</p>
 <pre><code class="language-css">@mixin optional-styles {
   @include description-lists;
   @include button;
@@ -186,7 +186,7 @@ docs.scss
 <pre><code class="language-html">&lt;link rel=&quot;stylesheet&quot; href=&quot;path/to/system.min.css&quot; /&gt;
 </code></pre>
 <h2>Next steps</h2>
-<p>Follow the HTML examples in individual components docs. If you are making a page layout from scratch, see <a href="https://DemocracyClub.github.io/design-system/usage/page-layout">Page layout</a>.</p>
+<p>Follow the HTML examples in individual components docs. If you are making a page layout from scratch, see <a href="/usage/page-layout">Page layout</a>.</p>
 
       </main>
     </div>

--- a/docs/usage/page-layout/index.html
+++ b/docs/usage/page-layout/index.html
@@ -2,127 +2,127 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="https://DemocracyClub.github.io/design-system/images/favicon.svg">
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/site.css" />
-    <link rel="stylesheet" href="https://DemocracyClub.github.io/design-system/styles/system.css" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link rel="stylesheet" href="/styles/system.css" />
     <title>Page layout (Democracy Club Design System)</title>
   </head>
   <body>
     <a href="#main">skip to content</a>
     <div>
       <nav>
-        <a href="https://DemocracyClub.github.io/design-system">
-          <img class="site-logo" src="https://DemocracyClub.github.io/design-system/images/logo.svg" alt="Design system homepage" />
+        <a href="">
+          <img class="site-logo" src="/images/logo.svg" alt="Design system homepage" />
         </a>
         <h2>Basics</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/getting-started"><strong>Getting started</strong></a>
+            <a href="/usage/getting-started"><strong>Getting started</strong></a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/colors/">Colors</a>
+            <a href="/basics/colors/">Colors</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/dark/">Dark theme</a>
+            <a href="/basics/dark/">Dark theme</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/forms/">Forms</a>
+            <a href="/basics/forms/">Forms</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/modular-scale/">Modular scale</a>
+            <a href="/basics/modular-scale/">Modular scale</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/basics/type/">Type</a>
+            <a href="/basics/type/">Type</a>
           </li>
         </ul>
         <h2>Components</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/breadcrumbs/">Breadcrumbs</a>
+            <a href="/components/breadcrumbs/">Breadcrumbs</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/button/">Button</a>
+            <a href="/components/button/">Button</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/call-to-action/">Call-to-action</a>
+            <a href="/components/call-to-action/">Call-to-action</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/candidate/">Candidate</a>
+            <a href="/components/candidate/">Candidate</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/card/">Card</a>
+            <a href="/components/card/">Card</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/checkbox/">Checkbox</a>
+            <a href="/components/checkbox/">Checkbox</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/cluster/">Cluster</a>
+            <a href="/components/cluster/">Cluster</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/codeblock/">Code block</a>
+            <a href="/components/codeblock/">Code block</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/description-lists/">Description lists</a>
+            <a href="/components/description-lists/">Description lists</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/details/">Details</a>
+            <a href="/components/details/">Details</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/filter/">Filter</a>
+            <a href="/components/filter/">Filter</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/footer/">Footer</a>
+            <a href="/components/footer/">Footer</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/grid/">Grid</a>
+            <a href="/components/grid/">Grid</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/header/">Header</a>
+            <a href="/components/header/">Header</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/language/">Language</a>
+            <a href="/components/language/">Language</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/logo/">Logo</a>
+            <a href="/components/logo/">Logo</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/radio-button/">Radio buttons</a>
+            <a href="/components/radio-button/">Radio buttons</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/select/">Select</a>
+            <a href="/components/select/">Select</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/sidebar/">Sidebar</a>
+            <a href="/components/sidebar/">Sidebar</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/stack/">Stack</a>
+            <a href="/components/stack/">Stack</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/status/">Status</a>
+            <a href="/components/status/">Status</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/subnavigation/">Sub-navigation</a>
+            <a href="/components/subnavigation/">Sub-navigation</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/table/">Table</a>
+            <a href="/components/table/">Table</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/components/utilities/">Utility classes</a>
+            <a href="/components/utilities/">Utility classes</a>
           </li>
         </ul>
         <h2>Composition</h2>
         <ul>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/composition/">Composing content</a>
+            <a href="/usage/composition/">Composing content</a>
           </li>
           <li>
-            <a href="https://DemocracyClub.github.io/design-system/usage/page-layout/">Page layout</a>
+            <a href="/usage/page-layout/">Page layout</a>
           </li>
         </ul>
       </nav>
       <main id="main" tabindex="-1">
         <h1>Page layout</h1>
-        <p>Instate a standard page layout by wrapping a skip link, <a href="https://DemocracyClub.github.io/design-system/components/language">Language</a> component, <a href="https://DemocracyClub.github.io/design-system/components/header">Header</a>, a main content area, and a <a href="https://DemocracyClub.github.io/design-system/components/footer">Footer</a> in a <code>&lt;div&gt;</code> with <code>class=&quot;ds-page&quot;</code> directly inside the <code>&lt;body&gt;</code> element.</p>
+        <p>Instate a standard page layout by wrapping a skip link, <a href="/components/language">Language</a> component, <a href="/components/header">Header</a>, a main content area, and a <a href="/components/footer">Footer</a> in a <code>&lt;div&gt;</code> with <code>class=&quot;ds-page&quot;</code> directly inside the <code>&lt;body&gt;</code> element.</p>
 <aside class="site-note site-stack" style="--stack-space: 1rem" aria-labelledby="skip-link">
   <h3 id="skip-link">🗒️ Skip link</h3>
   <div class="site-stack">
@@ -142,14 +142,14 @@
 <aside class="site-note site-stack" style="--stack-space: 1rem" aria-labelledby="demo">
   <h3 id="demo">🗒️ Demo</h3>
   <div class="site-stack">
-<p>See a <a href="https://DemocracyClub.github.io/design-system/layout-demo">demo of this basic page layout</a>.</p>
+<p>See a <a href="/layout-demo">demo of this basic page layout</a>.</p>
 </div>
 </aside>
 <h2>Notes</h2>
 <ul>
-<li>The <a href="https://DemocracyClub.github.io/design-system/components/header">Header</a> component’s prescribed markup includes a <a href="https://webaim.org/techniques/skipnav/">skip link</a>, so don’t implement one separately.</li>
+<li>The <a href="/components/header">Header</a> component’s prescribed markup includes a <a href="https://webaim.org/techniques/skipnav/">skip link</a>, so don’t implement one separately.</li>
 <li>For the skip link to work reliably in all browsers, the <code>&lt;main&gt;</code> element needs <code>id=&quot;main&quot;</code> and <code>tabindex=&quot;-1&quot;</code>.</li>
-<li>The <code>&lt;main&gt;</code> element needs <code>class=&quot;ds-stack&quot;</code> (see <a href="https://DemocracyClub.github.io/design-system/components.stack">Stack</a>) to insert margin between all the flow elements. For dealing with flow content, see <a href="https://DemocracyClub.github.io/design-system/usage/composition">Composing content</a>.</li>
+<li>The <code>&lt;main&gt;</code> element needs <code>class=&quot;ds-stack&quot;</code> (see <a href="/components.stack">Stack</a>) to insert margin between all the flow elements. For dealing with flow content, see <a href="/usage/composition">Composing content</a>.</li>
 </ul>
 
       </main>

--- a/src-site/layout.md
+++ b/src-site/layout.md
@@ -67,7 +67,7 @@ layout: layouts/bare.njk
     </ul>
   </aside>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Dignissimos pariatur iusto officia necessitatibus distinctio nemo perspiciatis placeat illo facilis enim soluta et accusamus sunt ipsa fugit earum, voluptas assumenda aspernatur.</p>
-    <dl class="ds-descriptions">
+  <dl class="ds-descriptions">
     <div>
       <dt>Facebook</dt>
       <dd><a href="https://www.facebook.com/shaunbaileyuk">www.facebook.com/shaunbaileyuk</a></dd>
@@ -88,6 +88,41 @@ layout: layouts/bare.njk
     </div>
   </dl>
   <p>Distinctio iure explicabo quaerat repudiandae, nulla officia corporis! Eaque sapiente excepturi quas, nostrum cumque nisi. Quis eligendi necessitatibus, fugit voluptatem a, voluptatibus praesentium fugiat, nostrum doloremque eum est ratione provident.</p>
+  <ul class="ds-grid">
+    <li class="ds-candidate">
+      <div class="ds-candidate-body ds-stack-smallest">
+        <h3 class="ds-candidate-name ds-h5">
+          <a href="path/to/candidate">Michael Rosen</a>
+        </h3>
+        <div class="ds-h6">Labour</div>
+      </div>
+      <div class="ds-candidate-image">
+        <img src="{{site.basedir}}/images/candidate_example.jpg" alt="">
+      </div>
+    </li>
+    <li class="ds-candidate">
+      <div class="ds-candidate-body ds-stack-smallest">
+        <h3 class="ds-candidate-name ds-h5">
+          <a href="path/to/candidate">David Moreland</a>
+        </h3>
+        <div class="ds-h6">Independent</div>
+      </div>
+      <div class="ds-candidate-image">
+        <img src="{{site.basedir}}/images/candidate_example_2.jpg" alt="">
+      </div>
+    </li>
+    <li class="ds-candidate">
+      <div class="ds-candidate-body ds-stack-smallest">
+        <h3 class="ds-candidate-name ds-h5">
+          <a href="path/to/candidate">Giles Orpen-Smellie</a>
+        </h3>
+        <div class="ds-h6">Conservative & Unionist Party</div>
+      </div>
+      <div class="ds-candidate-image">
+        <img src="{{site.basedir}}/images/candidate_example_3.jpg" alt="">
+      </div>
+    </li>
+  </ul>
   <h2>A subheading</h2>
   <p>Dignissimos asperiores sequi soluta, nemo voluptatum molestias repudiandae sunt mollitia placeat magnam sapiente inventore optio iure corporis facere laboriosam dolorem nisi nobis amet minima modi, adipisci tempora voluptatibus? Id, perspiciatis.</p>
   <div class="ds-candidate">

--- a/src-site/styles/system.css
+++ b/src-site/styles/system.css
@@ -623,7 +623,7 @@
     left: 0;
     z-index: 2; }
   .ds-scope .ds-candidate-image {
-    background-color: rgba(64, 63, 65, 0.2);
+    background-color: #efefef;
     flex-grow: 1;
     min-width: 10rem;
     min-width: min(10rem, 100%);
@@ -639,6 +639,23 @@
     .ds-scope .ds-candidate-image img {
       object-fit: cover;
       width: 100%; } }
+  @media (max-width: 400px) {
+    .ds-scope li.ds-candidate {
+      flex-wrap: nowrap; }
+    .ds-scope li .ds-candidate-body, .ds-scope li .ds-candidate-image {
+      padding: 1rem; }
+    .ds-scope li .ds-candidate-image {
+      background-color: transparent;
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      min-height: 0; }
+    .ds-scope li .ds-candidate-image img {
+      position: static;
+      object-fit: inherit;
+      height: 12vh;
+      width: auto;
+      margin-left: auto; } }
   .ds-scope .ds-candidate:focus-within {
     outline: 0.25rem solid #FFC037; }
   .ds-scope .ds-candidate:focus-within a:focus {

--- a/system/partials/_candidate.scss
+++ b/system/partials/_candidate.scss
@@ -33,7 +33,7 @@
   }
 
   .ds-candidate-image {
-    background-color: $blackOpacity;
+    background-color: #efefef;
     flex-grow: 1;
     min-width: 10rem;
     min-width: min(10rem, 100%);
@@ -53,6 +53,32 @@
     .ds-candidate-image img {
       object-fit: cover;
       width: 100%;
+    }
+  }
+
+  @media (max-width: 400px) {
+    li.ds-candidate {
+      flex-wrap: nowrap;
+    }
+
+    li .ds-candidate-body, li .ds-candidate-image {
+      padding: $s1;
+    }
+
+    li .ds-candidate-image {
+      background-color: transparent;
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      min-height: 0;
+    } 
+    
+    li .ds-candidate-image img {
+      position: static;
+      object-fit: inherit;
+      height: 12vh;
+      width: auto;
+      margin-left: auto;
     }
   }
 


### PR DESCRIPTION
* This fix applies to lists of candidates only
* The behavior should be checked against the `/layout-demo` page, not the `/components/candidate` page. The reason we are eschewing breakpoints as much as possible is because the effect differs depending on context, making reviewing the design system a bit confusing