### PR TITLE
WIP/Mobile improvements

### DIFF
--- a/system/partials/_breadcrumbs.scss
+++ b/system/partials/_breadcrumbs.scss
@@ -3,7 +3,6 @@
     @include fontMain;
     line-height: $lineHeight;
     margin: 0;
-    padding: 0;
     list-style: none;
   }
 

--- a/system/partials/_page.scss
+++ b/system/partials/_page.scss
@@ -7,7 +7,6 @@
     margin-left: auto;
     margin-right: auto;
     max-width: $measure;
-    margin-top: $s8;
     padding: 0 $s2;
   }
 }

--- a/system/partials/_type.scss
+++ b/system/partials/_type.scss
@@ -1,7 +1,6 @@
 @mixin type {
   input,
   button,
-  textarea,
   select {
     font: inherit;
   }


### PR DESCRIPTION
This PR includes various edits to improve layout on mobile devices: 

- Removing padding from breadcrumb navigation to align with logo in header

- Excluding text area from type.scss import; which results in a more proportionate input area. Feedback text area will now fit in mobile view.

- Removing margin-top from ds-page main reduces the unused white space. 

- Removing margin-right from ds-logo centers the logo in the footer. 