### PR TITLE
Center the copyright p block

### DIFF
--- a/docs/styles/system.css
+++ b/docs/styles/system.css
@@ -142,7 +142,9 @@
   max-width: none; }
 
 .ds-scope .ds-copyright p {
-  margin: 0 !important; }
+  max-width: 100ch; 
+  margin: 0 !important; 
+}
 
 .ds-scope .ds-copyright img {
   max-width: 15rem;


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/design-system/issues/31
Increasing the `max-width:` from `70ch` to `100ch` removed the extra margin. 

![Screen Shot 2022-04-04 at 3 40 31 PM](https://user-images.githubusercontent.com/7017118/161570193-04fe7eb8-922d-42f5-9c39-a99ccb495d6f.png)
![Screen Shot 2022-04-04 at 3 49 15 PM](https://user-images.githubusercontent.com/7017118/161570411-2e5dd2f0-1b0d-4efb-b4ec-39b728a09975.png)

