### PR TITLE
Override parent class max width

### DIFF
--- a/docs/styles/system.css
+++ b/docs/styles/system.css
@@ -142,7 +142,7 @@
   max-width: none; }
 
 .ds-scope .ds-copyright p {
-  max-width: 100ch;
+  max-width: 100ch !important;
   margin: 0 !important; }
 
 .ds-scope .ds-copyright img {

--- a/src-site/styles/system.css
+++ b/src-site/styles/system.css
@@ -142,7 +142,7 @@
   max-width: none; }
 
 .ds-scope .ds-copyright p {
-  max-width: 100ch;
+  max-width: 100ch !important;
   margin: 0 !important; }
 
 .ds-scope .ds-copyright img {

--- a/system/partials/_footer.scss
+++ b/system/partials/_footer.scss
@@ -11,7 +11,7 @@
 }
 
 %ds-copyright p {
-  max-width: 100ch;
+  max-width: 100ch !important;
   margin: 0 !important; 
 }
 


### PR DESCRIPTION
I think the reason that the changes to `max-width` in `ds-copyright p` from the current version didn't work is because the parent class `.ds-copyright` `max-width` was set to `none`. This work overrides that setting just for child `<p>` tags. 