### PR TITLE
Exclude link styling on logo

### DIFF
--- a/src-site/styles/system.css
+++ b/src-site/styles/system.css
@@ -782,7 +782,10 @@
     margin-right: 0.625rem; }
   .ds-scope .ds-logo span {
     font-weight: 300;
-    font-size: 1.5625rem; }
+    font-size: 1.5625rem;
+    color: black;
+    text-decoration: none; 
+  }
   .ds-scope .ds-logo em {
     display: block;
     font-size: 1.25rem;

--- a/system/partials/_logo.scss
+++ b/system/partials/_logo.scss
@@ -19,6 +19,8 @@
   .ds-logo span {
     font-weight: 300;
     font-size: $s3;
+    text-decoration: none;
+    color: $black;
   }
 
   .ds-logo em {


### PR DESCRIPTION
The previous PR/version corrected text colour on nested elements within a link. This change ensures that the logo is not affected by that styling. 