### PR TITLE
Explicitly require and install `npm-run-build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "cssMin": "csso src-site/styles/system.css --output src-site/styles/system.min.css",
     "watch:eleventy": "npm run exportSass && eleventy --serve",
     "build:eleventy": "cross-env DESTINATION=github eleventy --output=docs",
-    "reinstallNodeModules": "rm -rf node_modules && npm install",
+    "reinstallNodeModules": "rm -rf node_modules && npm install && npm install npm-run-all --save-dev",
     "exportSass": "sass-export system/partials/_variables.scss -o src-site/_data/sass.json --dependencies system/",
     "watch:sass": "node-sass --watch system/docs.scss src-site/styles/system.css",
     "build:sass": "node-sass system/docs.scss src-site/styles/system.css",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 authors = [{name = "Sym Roe"}, {name = "Heydon Pickering"}]
 
 dependencies = [
+	"npm-run-all",
 	"pytest",
 	"lighthouse @ git+https://github.com/f02h/lighthouse-python.git#egg=lighthouse",
 ]


### PR DESCRIPTION
This is another attempt to find this command in the deploy step.