### PR TITLE
Use npx for `npm-run-all`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "cssMin": "csso src-site/styles/system.css --output src-site/styles/system.min.css",
     "watch:eleventy": "npm run exportSass && eleventy --serve",
     "build:eleventy": "cross-env DESTINATION=github eleventy --output=docs",
-    "reinstallNodeModules": "rm -rf node_modules && npm install && npm install npm-run-all --save-dev",
+    "reinstallNodeModules": "rm -rf node_modules && npm install && npx npm-run-all --save-dev",
     "exportSass": "sass-export system/partials/_variables.scss -o src-site/_data/sass.json --dependencies system/",
     "watch:sass": "node-sass --watch system/docs.scss src-site/styles/system.css",
     "build:sass": "node-sass system/docs.scss src-site/styles/system.css",
-    "start": "npm run copyAssets && npm rebuild node-sass && npm-run-all build:sass --parallel watch:*",
-    "build": "npm run copyAssets && npm run exportSass && npm-run-all build:*"
+    "start": "npm run copyAssets && npm rebuild node-sass && npx npm-run-all build:sass --parallel watch:*",
+    "build": "npm run copyAssets && npm run exportSass && npx npm-run-all build:*"
   },
   "husky": {
     "hooks": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dc_design_system"
-version = "2.6.6"
+version = "0.4.12"
 description = "SCSS and images for the DC design system"
 readme = "README.md"
 authors = [{name = "Sym Roe"}, {name = "Heydon Pickering"}]


### PR DESCRIPTION
The deployment of `dc_utils` to pypi is blocked by a restriction that does not allow direct dependencies (in this case, the design system). This change aims to address this error for installing `npm-run-all` https://github.com/DemocracyClub/design-system/actions/runs/8633750907/job/23667545198#step:5:196

Related thread https://github.com/mysticatea/npm-run-all/issues/96

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206929626417180