### PR TITLE
Implement footer links and revised copyright

### DIFF
--- a/src-site/components/footer.md
+++ b/src-site/components/footer.md
@@ -21,16 +21,13 @@ to your needs. In the following example, a list of “quick links” is provided
           <h2>ProjectName</h2>
           <ul>
             <li>
-              <a href="/">Home</a>
+              <a href="#">Home</a>
             </li>
             <li>
-              <a aria-current="true" href="/path/to/about">About</a>
+              <a href="#">About</a>
             </li>
             <li>
-              <a href="/path/to/">Our work</a>
-            </li>
-            <li>
-              <a href="#">Quests</a>
+              <a href="#">Our work</a>
             </li>
             <li>
               <a href="#">Blog</a>
@@ -47,13 +44,13 @@ to your needs. In the following example, a list of “quick links” is provided
           <h2>About</h2>
           <ul>
             <li>
-              <a href="/">Home</a>
+              <a href="#">Home</a>
             </li>
             <li>
-              <a aria-current="true" href="/path/to/about">About</a>
+              <a href="#">About</a>
             </li>
             <li>
-              <a href="/path/to/">Our work</a>
+              <a href="#">Our work</a>
             </li>
             <li>
               <a href="#">Quests</a>
@@ -73,25 +70,13 @@ to your needs. In the following example, a list of “quick links” is provided
           <h2>Contact</h2>
           <ul>
             <li>
-              <a href="/">Home</a>
+              <a href="#">Email</a>
             </li>
             <li>
-              <a aria-current="true" href="/path/to/about">About</a>
+              <a href="#">Mastodon</a>
             </li>
             <li>
-              <a href="/path/to/">Our work</a>
-            </li>
-            <li>
-              <a href="#">Quests</a>
-            </li>
-            <li>
-              <a href="#">Blog</a>
-            </li>
-            <li>
-              <a href="#">Contact</a>
-            </li>
-            <li>
-              <a href="#">Donate</a>
+              <a href="#">LinkedIn</a>
             </li>
           </ul>
         </nav>
@@ -116,16 +101,13 @@ to your needs. In the following example, a list of “quick links” is provided
           <h2>ProjectName</h2>
           <ul>
             <li>
-              <a href="/">Home</a>
+              <a href="#">Home</a>
             </li>
             <li>
-              <a aria-current="true" href="/path/to/about">About</a>
+              <a href="#">About</a>
             </li>
             <li>
-              <a href="/path/to/">Our work</a>
-            </li>
-            <li>
-              <a href="#">Quests</a>
+              <a href="#">Our work</a>
             </li>
             <li>
               <a href="#">Blog</a>
@@ -142,13 +124,13 @@ to your needs. In the following example, a list of “quick links” is provided
           <h2>About</h2>
           <ul>
             <li>
-              <a href="/">Home</a>
+              <a href="#">Home</a>
             </li>
             <li>
-              <a aria-current="true" href="/path/to/about">About</a>
+              <a href="#">About</a>
             </li>
             <li>
-              <a href="/path/to/">Our work</a>
+              <a href="#">Our work</a>
             </li>
             <li>
               <a href="#">Quests</a>
@@ -168,25 +150,13 @@ to your needs. In the following example, a list of “quick links” is provided
           <h2>Contact</h2>
           <ul>
             <li>
-              <a href="/">Home</a>
+              <a href="#">Email</a>
             </li>
             <li>
-              <a aria-current="true" href="/path/to/about">About</a>
+              <a href="#">Mastodon</a>
             </li>
             <li>
-              <a href="/path/to/">Our work</a>
-            </li>
-            <li>
-              <a href="#">Quests</a>
-            </li>
-            <li>
-              <a href="#">Blog</a>
-            </li>
-            <li>
-              <a href="#">Contact</a>
-            </li>
-            <li>
-              <a href="#">Donate</a>
+              <a href="#">LinkedIn</a>
             </li>
           </ul>
         </nav>

--- a/src-site/components/footer.md
+++ b/src-site/components/footer.md
@@ -6,72 +6,194 @@ Use the Footer component to add quick links, company, and contact information to
 
 A basic footer looks something like the following (as seen in [the page layout demo]({{site.basedir}}/layout-demo/). All the `ds-footer` class does is add some padding, the blue top border, and extend the [Dark theme]({{site.basedir}}/basics/dark).
 
-Aside from that, only `ds-copyright` is unique to this component. The content of the footer can be constructed from other components according to your needs. In the following example, a list of “quick links” is provided alongside the copyright.
+Aside from that, `ds-copyright` and `ds-footer-links` are unique to this 
+component. The content of the footer can be constructed from other components according 
+to your needs. In the following example, a list of “quick links” is provided alongside the copyright.
 
 {% ds-example %}
-  <footer class="ds-footer">
-    <div class="ds-block-centered ds-text-centered ds-stack">
-      <div class="ds-cluster-center">
-        <ul>
-          <li>
-            <a href="/">Home</a>
-          </li>
-          <li>
-            <a aria-current="true" href=".path/to/about">About</a>
-          </li>
-          <li>
-            <a href="/path/to/">Our work</a>
-          </li>
-          <li>
-            <a href="#">Quests</a>
-          </li>
-          <li>
-            <a href="#">Blog</a>
-          </li>
-          <li>
-            <a href="#">Contact</a>
-          </li>
-          <li>
-            <a href="#">Donate</a>
-          </li>
-        </ul>
+
+<footer class="ds-footer">
+    <a class="ds-logo" href="https://democracyclub.org.uk/">
+        <img src="{{site.basedir}}/images/logo_icon.svg" alt="Democracy Club" width='80'/>
+    </a>
+    <div class="ds-footer-links"> 
+        <nav>
+          <h2>ProjectName</h2>
+          <ul>
+            <li>
+              <a href="/">Home</a>
+            </li>
+            <li>
+              <a aria-current="true" href="/path/to/about">About</a>
+            </li>
+            <li>
+              <a href="/path/to/">Our work</a>
+            </li>
+            <li>
+              <a href="#">Quests</a>
+            </li>
+            <li>
+              <a href="#">Blog</a>
+            </li>
+            <li>
+              <a href="#">Contact</a>
+            </li>
+            <li>
+              <a href="#">Donate</a>
+            </li>
+          </ul>
+        </nav>
+        <nav>
+          <h2>About</h2>
+          <ul>
+            <li>
+              <a href="/">Home</a>
+            </li>
+            <li>
+              <a aria-current="true" href="/path/to/about">About</a>
+            </li>
+            <li>
+              <a href="/path/to/">Our work</a>
+            </li>
+            <li>
+              <a href="#">Quests</a>
+            </li>
+            <li>
+              <a href="#">Blog</a>
+            </li>
+            <li>
+              <a href="#">Contact</a>
+            </li>
+            <li>
+              <a href="#">Donate</a>
+            </li>
+          </ul>
+        </nav>
+        <nav>
+          <h2>Contact</h2>
+          <ul>
+            <li>
+              <a href="/">Home</a>
+            </li>
+            <li>
+              <a aria-current="true" href="/path/to/about">About</a>
+            </li>
+            <li>
+              <a href="/path/to/">Our work</a>
+            </li>
+            <li>
+              <a href="#">Quests</a>
+            </li>
+            <li>
+              <a href="#">Blog</a>
+            </li>
+            <li>
+              <a href="#">Contact</a>
+            </li>
+            <li>
+              <a href="#">Donate</a>
+            </li>
+          </ul>
+        </nav>
       </div>
       <div class="ds-copyright">
-        <a class="ds-logo" href="https://democracyclub.org.uk/">
-            <img src="{{site.basedir}}/images/logo_icon.svg" alt="Democracy Club" width='80'/>
-            <span class="ds-text-left">democracy<br>club</span>
-        </a>
-        <p>Copyright © 2023 Democracy Club</p>
-        <p>Community Interest Company</p>
-        <p>Company No: <a href="https://beta.companieshouse.gov.uk/company/09461226">09461226</a></p>
+        <p>Democracy Club is a UK-based Community Interest Company that builds digital infrastructure for a 21st century democracy.</p>
+        <p>Copyright © 2024 Democracy Club Community Interest Company No: <a href="https://beta.companieshouse.gov.uk/company/09461226">09461226</a></p>
       </div>
-    </div>
-  </footer>
+</footer>
 {% endds-example %}
 
 
 ## Markup
 
-The unique class names for this component are the containing `ds-footer` and `ds-copyright`. Everything else, including the dark theme, the “clustered” navigation and the center alignment is achieved with other component helpers and utilities.
-
 ```html
 <footer class="ds-footer">
-  <div class="ds-block-centered ds-text-centered ds-stack">
-    <div class="ds-cluster-center">
-      <ul>
-        <!-- list items -->
-      </ul>
-    </div>
-    <div class="ds-copyright">
-      <a class="ds-logo" href="https://democracyclub.org.uk/">
-        <img src="{{site.basedir}}/images/logo_white_text.svg" alt="Democracy Club Home" />
-        <span>democracy<br>club</span>
-      </a>
-      <p>Copyright © 2024
-         Democracy Club</p>
-      <p>Community Interest Company</p>
-      <p>Company No: <a href="https://beta.companieshouse.gov.uk/company/09461226">09461226</a></p>
-    </div>
-  </div>
+    <a class="ds-logo" href="https://democracyclub.org.uk/">
+        <img src="{{site.basedir}}/images/logo_icon.svg" alt="Democracy Club" width='80'/>
+    </a>
+    <div class="ds-footer-links"> 
+        <nav>
+          <h2>ProjectName</h2>
+          <ul>
+            <li>
+              <a href="/">Home</a>
+            </li>
+            <li>
+              <a aria-current="true" href="/path/to/about">About</a>
+            </li>
+            <li>
+              <a href="/path/to/">Our work</a>
+            </li>
+            <li>
+              <a href="#">Quests</a>
+            </li>
+            <li>
+              <a href="#">Blog</a>
+            </li>
+            <li>
+              <a href="#">Contact</a>
+            </li>
+            <li>
+              <a href="#">Donate</a>
+            </li>
+          </ul>
+        </nav>
+        <nav>
+          <h2>About</h2>
+          <ul>
+            <li>
+              <a href="/">Home</a>
+            </li>
+            <li>
+              <a aria-current="true" href="/path/to/about">About</a>
+            </li>
+            <li>
+              <a href="/path/to/">Our work</a>
+            </li>
+            <li>
+              <a href="#">Quests</a>
+            </li>
+            <li>
+              <a href="#">Blog</a>
+            </li>
+            <li>
+              <a href="#">Contact</a>
+            </li>
+            <li>
+              <a href="#">Donate</a>
+            </li>
+          </ul>
+        </nav>
+        <nav>
+          <h2>Contact</h2>
+          <ul>
+            <li>
+              <a href="/">Home</a>
+            </li>
+            <li>
+              <a aria-current="true" href="/path/to/about">About</a>
+            </li>
+            <li>
+              <a href="/path/to/">Our work</a>
+            </li>
+            <li>
+              <a href="#">Quests</a>
+            </li>
+            <li>
+              <a href="#">Blog</a>
+            </li>
+            <li>
+              <a href="#">Contact</a>
+            </li>
+            <li>
+              <a href="#">Donate</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div class="ds-copyright">
+        <p>Democracy Club is a UK-based Community Interest Company that builds digital infrastructure for a 21st century democracy.</p>
+        <p>Copyright © 2024 Democracy Club Community Interest Company No: <a href="https://beta.companieshouse.gov.uk/company/09461226">09461226</a></p>
+      </div>
 </footer>
 ```

--- a/src-site/layout_content.md
+++ b/src-site/layout_content.md
@@ -134,34 +134,77 @@
   </div>
 </main>
 <footer class="ds-footer">
-  <div class="ds-block-centered ds-text-centered ds-stack">
-    <form>
-      <div class="ds-field">
-        <label for="username">
-          Username
-          <small>Or enter your email address</small>
-        </label>
-        <input type="text" id="username">
+    <a class="ds-logo" href="https://democracyclub.org.uk/">
+        <img src="{{site.basedir}}/images/logo_icon.svg" alt="Democracy Club" width='80'/>
+    </a>
+    <div class="ds-footer-links"> 
+        <nav>
+          <h2>ProjectName</h2>
+          <ul>
+            <li>
+              <a href="#">Home</a>
+            </li>
+            <li>
+              <a href="#">About</a>
+            </li>
+            <li>
+              <a href="#">Our work</a>
+            </li>
+            <li>
+              <a href="#">Blog</a>
+            </li>
+            <li>
+              <a href="#">Contact</a>
+            </li>
+            <li>
+              <a href="#">Donate</a>
+            </li>
+          </ul>
+        </nav>
+        <nav>
+          <h2>About</h2>
+          <ul>
+            <li>
+              <a href="#">Home</a>
+            </li>
+            <li>
+              <a href="#">About</a>
+            </li>
+            <li>
+              <a href="#">Our work</a>
+            </li>
+            <li>
+              <a href="#">Quests</a>
+            </li>
+            <li>
+              <a href="#">Blog</a>
+            </li>
+            <li>
+              <a href="#">Contact</a>
+            </li>
+            <li>
+              <a href="#">Donate</a>
+            </li>
+          </ul>
+        </nav>
+        <nav>
+          <h2>Contact</h2>
+          <ul>
+            <li>
+              <a href="#">Email</a>
+            </li>
+            <li>
+              <a href="#">Mastodon</a>
+            </li>
+            <li>
+              <a href="#">LinkedIn</a>
+            </li>
+          </ul>
+        </nav>
       </div>
-    </form>
-    <div class="ds-footer-links">
-      <nav>
-        <h2 class="ds-h5">Contact Democracy Club</h2>
-        <ul>
-          <li><a href="/">Home</a></li>
-          <li><a aria-current="true" href="/path/to/about">About</a></li>
-          <li><a href="/path/to/">Our work</a></li>
-          <li><a href="#">Quests</a></li>
-          <li><a href="#">Blog</a></li>
-          <li><a href="#">Contact</a></li>
-          <li><a href="#">Donate</a></li>
-        </ul>
-      </nav>
-    </div>
-    <div class="ds-copyright">
-      <p>Democracy Club is a UK-based Community Interest Company that builds digital infrastructure for a 21st century democracy.</p>
-      <p>Copyright © 2024 Democracy Club Community Interest Company No: <a href="https://beta.companieshouse.gov.uk/company/09461226">09461226</a></p>
-    </div>
-  </div>
+      <div class="ds-copyright">
+        <p>Democracy Club is a UK-based Community Interest Company that builds digital infrastructure for a 21st century democracy.</p>
+        <p>Copyright © 2024 Democracy Club Community Interest Company No: <a href="https://beta.companieshouse.gov.uk/company/09461226">09461226</a></p>
+      </div>
 </footer>
 ```

--- a/src-site/layout_content.md
+++ b/src-site/layout_content.md
@@ -144,39 +144,24 @@
         <input type="text" id="username">
       </div>
     </form>
-    <div class="ds-cluster-center">
-      <ul>
-        <li>
-          <a href="/">Home</a>
-        </li>
-        <li>
-          <a aria-current="true" href=".path/to/about">About</a>
-        </li>
-        <li>
-          <a href="/path/to/">Our work</a>
-        </li>
-        <li>
-          <a href="#">Quests</a>
-        </li>
-        <li>
-          <a href="#">Blog</a>
-        </li>
-        <li>
-          <a href="#">Contact</a>
-        </li>
-        <li>
-          <a href="#">Donate</a>
-        </li>
-      </ul>
+    <div class="ds-footer-links">
+      <nav>
+        <h2 class="ds-h5">Contact Democracy Club</h2>
+        <ul>
+          <li><a href="/">Home</a></li>
+          <li><a aria-current="true" href="/path/to/about">About</a></li>
+          <li><a href="/path/to/">Our work</a></li>
+          <li><a href="#">Quests</a></li>
+          <li><a href="#">Blog</a></li>
+          <li><a href="#">Contact</a></li>
+          <li><a href="#">Donate</a></li>
+        </ul>
+      </nav>
     </div>
-    <div class="ds-copyright ds-text-centered">
-      <a class="ds-logo" href="https://democracyclub.org.uk/">
-        <img src="{{site.basedir}}/images/logo_icon.svg" alt="Democracy Club Home" width='80'/>
-        <span>democracy<br>club</span>
-      </a>
-      <p>Copyright © 2024 Democracy Club</p>
-      <p>Community Interest Company</p>
-      <p>Company No: <a href="https://beta.companieshouse.gov.uk/company/09461226">09461226</a></p>
+    <div class="ds-copyright">
+      <p>Democracy Club is a UK-based Community Interest Company that builds digital infrastructure for a 21st century democracy.</p>
+      <p>Copyright © 2024 Democracy Club Community Interest Company No: <a href="https://beta.companieshouse.gov.uk/company/09461226">09461226</a></p>
     </div>
   </div>
 </footer>
+```

--- a/src-site/styles/system.css
+++ b/src-site/styles/system.css
@@ -15,10 +15,10 @@
 
 .ds-scope .ds-stack-larger > *,
 .ds-scope .ds-stack > *,
-.ds-scope .ds-footer > *,
 .ds-scope .ds-card .ds-card-body > *,
 .ds-scope hgroup > *,
 .ds-scope .ds-stack-smaller > *,
+.ds-scope .ds-footer > *,
 .ds-scope .ds-filter > *,
 .ds-scope .ds-stack-smallest > *,
 .ds-scope .ds-advanced-filters > * {
@@ -27,10 +27,10 @@
 .ds-scope .ds-stack-larger > * + * {
   margin-top: 4.76837rem; }
 
-.ds-scope .ds-stack > * + *, .ds-scope .ds-footer > * + * {
+.ds-scope .ds-stack > * + * {
   margin-top: 3.05176rem; }
 
-.ds-scope .ds-card .ds-card-body > * + *, .ds-scope hgroup > * + *, .ds-scope .ds-stack-smaller > * + *, .ds-scope .ds-filter > * + * {
+.ds-scope .ds-card .ds-card-body > * + *, .ds-scope hgroup > * + *, .ds-scope .ds-stack-smaller > * + *, .ds-scope .ds-footer > * + *, .ds-scope .ds-filter > * + * {
   margin-top: 1.5625rem; }
 
 .ds-scope .ds-stack-smallest > * + *, .ds-scope .ds-advanced-filters > * + * {
@@ -158,10 +158,11 @@
 .ds-scope .ds-footer-links > * {
   --gridCellMin: 20ch; }
 
-.ds-scope .ds-footer-links nav ul {
-  margin-top: 1.25rem;
-  list-style: none;
-  padding: 0; }
+.ds-scope .ds-footer-links nav {
+  margin-top: 1.25rem; }
+  .ds-scope .ds-footer-links nav ul {
+    list-style: none;
+    padding: 0; }
 
 .ds-scope .ds-copyright {
   padding: 1.95312rem;
@@ -559,7 +560,7 @@
   .ds-scope .ds-dark .ds-field-error {
     color: #FF6347;
     font-size: 1em; }
-  .ds-scope .ds-stack > :is(h1, h2, h3, h4, h5, hgroup) + *:not(article), .ds-scope .ds-footer > :is(h1, h2, h3, h4, h5, hgroup) + *:not(article) {
+  .ds-scope .ds-stack > :is(h1, h2, h3, h4, h5, hgroup) + *:not(article) {
     margin-top: 1rem; }
   .ds-scope dl.ds-descriptions > div {
     display: flex;

--- a/src-site/styles/system.css
+++ b/src-site/styles/system.css
@@ -15,11 +15,11 @@
 
 .ds-scope .ds-stack-larger > *,
 .ds-scope .ds-stack > *,
+.ds-scope .ds-footer > *,
 .ds-scope .ds-card .ds-card-body > *,
 .ds-scope hgroup > *,
 .ds-scope .ds-stack-smaller > *,
 .ds-scope .ds-filter > *,
-.ds-scope .ds-copyright > *,
 .ds-scope .ds-stack-smallest > *,
 .ds-scope .ds-advanced-filters > * {
   margin: 0; }
@@ -27,13 +27,13 @@
 .ds-scope .ds-stack-larger > * + * {
   margin-top: 4.76837rem; }
 
-.ds-scope .ds-stack > * + * {
+.ds-scope .ds-stack > * + *, .ds-scope .ds-footer > * + * {
   margin-top: 3.05176rem; }
 
 .ds-scope .ds-card .ds-card-body > * + *, .ds-scope hgroup > * + *, .ds-scope .ds-stack-smaller > * + *, .ds-scope .ds-filter > * + * {
   margin-top: 1.5625rem; }
 
-.ds-scope .ds-copyright > * + *, .ds-scope .ds-stack-smallest > * + *, .ds-scope .ds-advanced-filters > * + * {
+.ds-scope .ds-stack-smallest > * + *, .ds-scope .ds-advanced-filters > * + * {
   margin-top: 0.25rem; }
 
 .ds-scope .ds-cluster > *, .ds-scope .ds-language > *, .ds-scope .ds-header nav a:not(.ds-cta) > *, .ds-scope .ds-subnav > *, .ds-scope .ds-filter-cluster > *,
@@ -140,7 +140,7 @@
   color: #fff; }
 
 .ds-scope .ds-footer {
-  padding: 4.76837rem 1.25rem;
+  padding: 1.95312rem 1.25rem;
   border-top: 0.5rem solid #007CAD;
   margin-top: 4.76837rem;
   background-color: #403F41;
@@ -149,28 +149,24 @@
 .ds-scope .ds-footer form {
   background-color: #403F41; }
 
-.ds-scope .ds-footer a {
-  color: #fff; }
+.ds-scope .ds-footer * {
+  color: #fff;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 70ch; }
 
-.ds-scope .ds-footer .ds-copyright p {
-  color: #fff; }
+.ds-scope .ds-footer-links > * {
+  --gridCellMin: 20ch; }
 
-.ds-scope .ds-footer .ds-logo img {
-  margin-right: 0.375rem; }
-
-.ds-scope .ds-footer .ds-logo span {
-  color: #fff; }
+.ds-scope .ds-footer-links nav ul {
+  margin-top: 1.25rem;
+  list-style: none;
+  padding: 0; }
 
 .ds-scope .ds-copyright {
-  max-width: none; }
-
-.ds-scope .ds-copyright p {
-  max-width: 100ch;
-  margin: 0 !important; }
-
-.ds-scope .ds-copyright img {
-  max-width: 15rem;
-  margin-bottom: 0.5rem; }
+  padding: 1.95312rem;
+  background-color: #403F41;
+  max-width: 100%; }
 
 .ds-scope .ds-dark {
   color: #fff;
@@ -220,7 +216,7 @@
 .ds-scope .ds-text-left {
   text-align: left; }
 
-.ds-scope .ds-text-centered {
+.ds-scope .ds-text-centered, .ds-scope .ds-footer, .ds-scope .ds-footer-links {
   text-align: center; }
 
 .ds-scope .ds-text-right {
@@ -237,7 +233,7 @@
 .ds-scope .ds-block-centered-narrow {
   max-width: 50ch; }
 
-.ds-scope .ds-width-full, .ds-scope .ds-switcher > * {
+.ds-scope .ds-width-full, .ds-scope .ds-switcher > *, .ds-scope .ds-footer-links > * {
   display: block;
   max-width: none;
   width: auto; }
@@ -477,7 +473,7 @@
   .ds-scope h4, .ds-scope .ds-h4, .ds-scope .ds-showcase strong {
     font-size: 1.95312rem;
     font-size: clamp(1.25rem, 4vw, 1.95312rem); }
-  .ds-scope h5, .ds-scope .ds-h5 {
+  .ds-scope h5, .ds-scope .ds-h5, .ds-scope .ds-footer-links h2 {
     font-size: 1.5625rem;
     font-size: clamp(1rem, 3vw, 1.5625rem); }
   .ds-scope h6, .ds-scope .ds-h6 {
@@ -563,7 +559,7 @@
   .ds-scope .ds-dark .ds-field-error {
     color: #FF6347;
     font-size: 1em; }
-  .ds-scope .ds-stack > :is(h1, h2, h3, h4, h5, hgroup) + *:not(article) {
+  .ds-scope .ds-stack > :is(h1, h2, h3, h4, h5, hgroup) + *:not(article), .ds-scope .ds-footer > :is(h1, h2, h3, h4, h5, hgroup) + *:not(article) {
     margin-top: 1rem; }
   .ds-scope dl.ds-descriptions > div {
     display: flex;
@@ -882,12 +878,11 @@
   .ds-scope .ds-dark .ds-footer {
     background-color: #0D1117; }
   .ds-scope .ds-dark .ds-footer .ds-copyright {
-    color: #fff; }
+    color: #fff;
+    background-color: #0D1117; }
   .ds-scope .ds-dark .ds-footer form {
     background-color: #0D1117;
     border: none; }
-  .ds-scope .ds-dark .ds-logo span {
-    color: #fff; }
   .ds-scope .ds-field-radio {
     display: flex;
     align-items: center;
@@ -1136,13 +1131,13 @@
     box-sizing: border-box; }
   .ds-scope .ds-date .ds-field:last-child input {
     max-width: 6em; }
-  .ds-scope .ds-switcher {
+  .ds-scope .ds-switcher, .ds-scope .ds-footer-links {
     --gridGap: 1.25rem;
     --gridCellMin: 30ch;
     display: flex;
     flex-wrap: wrap;
     gap: var(--gridGap); }
-  .ds-scope .ds-switcher > * {
+  .ds-scope .ds-switcher > *, .ds-scope .ds-footer-links > * {
     flex-grow: 1;
     flex-basis: var(--gridCellMin); }
   .ds-scope .ds-showcase li {

--- a/system/partials/_footer.scss
+++ b/system/partials/_footer.scss
@@ -1,49 +1,61 @@
 %ds-footer {
-  padding: $s8 $s2;
+  @extend .ds-stack;
+  padding: $s4 $s2;
   border-top: $ss4 solid $blueForWhite;
   margin-top: $s8;
   background-color: $black;
   color: $white;
+
 }
 
 %ds-footer form {
   background-color: $black;
 }
 
-%ds-footer a {
+%ds-footer * {
   color: $white;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 70ch;
 }
 
-%ds-footer .ds-copyright p {
-  color: $white;
+%ds-footer {
+    @extend .ds-text-centered;
 }
 
-%ds-footer .ds-logo img {
-  margin-right: $ss3;
-}
+%ds-footer-links {
 
-%ds-footer .ds-logo span {
-  color: $white;
+  @extend .ds-switcher;
+  @extend .ds-text-centered;
+
+  &> * {
+    --gridCellMin: 20ch;
+  }
+
+  h2 {
+    @extend .ds-h5;
+  }
+
+  nav {
+    ul {
+      margin-top: $s2;
+      list-style: none;
+      padding:0;
+    }
+
+  }
 }
 
 %ds-copyright {
-  max-width: none;
-  @extend %ds-stack-smallest;
+  padding: $s4;
+  background-color: $black;
+  max-width:100%;
 }
-
-%ds-copyright p {
-  max-width: 100ch;
-  margin: 0 !important;
-}
-%ds-copyright img {
-  max-width: 15rem;
-  margin-bottom: $ss4;
-}
-
 
 @mixin footer {
   .ds-footer { @extend %ds-footer; }
-  .ds-copyright { @extend %ds-copyright }
+  .ds-copyright { @extend %ds-copyright; }
+  .ds-footer-links { @extend %ds-footer-links; }
 
   // Dark theme
   .ds-dark {
@@ -53,15 +65,12 @@
 
     .ds-footer .ds-copyright {
       color: $white;
+      background-color: $darkBlack;
     }
 
     .ds-footer form {
       background-color: $darkBlack;
       border:none;
-    }
-
-    .ds-logo span {
-      color: $white;
     }
   }
 }

--- a/system/partials/_footer.scss
+++ b/system/partials/_footer.scss
@@ -1,5 +1,5 @@
 %ds-footer {
-  @extend .ds-stack;
+  @extend .ds-stack-smaller;
   padding: $s4 $s2;
   border-top: $ss4 solid $blueForWhite;
   margin-top: $s8;
@@ -37,8 +37,12 @@
   }
 
   nav {
+
+    margin-top: $s2;
+
+
+
     ul {
-      margin-top: $s2;
       list-style: none;
       padding:0;
     }


### PR DESCRIPTION
Ref https://github.com/DemocracyClub/design-system/issues/140

Of the suggestions in the original issue, these are the changes implemented (so far) in this PR: 

- [x] Split footer into two parts: links at the top (#403F41), mission statement and company info below (#000000). 
This raised questions about what to do in dark mode so for simplicity, I've used a blue line to divide the sections as shown below. 
- [x] Links at the top grouped into three categories: 'Who Can I Vote For?', 'Made by Democracy Club', 'Connect with us' (you can rename these). Each category has links related to either WCIVF, Democracy Club or social media.
- [x] Links on phone screens will use the one column layout and be displayed under each other.
- [x] Links on larger screens (from the size of a tablet screen in portrait view) will use a three column layout and be displayed in parallel columns.
- [x] Mission statement, copyright, company information at the bottom of the page 
- [x] the above, on a darker background.
- [x] Headings in white, in bolder font.
- [x] Headings, links, mission statement, copyright can use the same font sizes as it is currently or copyright could be about 2px smaller (relative to the screen size).

**Questions for Reviewers:**
- [x] What is the ideal mobile layout given that the mockup in the issue has fewer footer links that we would like have, at least on Website? 

![Screenshot 2024-10-23 at 12 30 37 PM](https://github.com/user-attachments/assets/1f913949-d6bd-4532-bda9-272f0d9568b8)
![Screenshot 2024-10-23 at 12 30 29 PM](https://github.com/user-attachments/assets/a31a49e8-4d41-448c-b256-54862809b2a0)
